### PR TITLE
[WIP]: Removes remove file button from UI

### DIFF
--- a/fields/types/file/FileField.js
+++ b/fields/types/file/FileField.js
@@ -197,7 +197,6 @@ module.exports = Field.create({
 				<Button onClick={this.triggerFileBrowser}>
 					{this.hasFile() ? 'Change' : 'Upload'} File
 				</Button>
-				{this.hasFile() && this.renderClearButton()}
 			</div>
 		);
 


### PR DESCRIPTION
Removes the 'Remove File' button from the admin UI, on resident info editing page.

Reason: LMCBUG-48 Jira ticket
There is a keystone limitation which does not allow to remove the file through the UI. After discussing it, we agreed to remove the 'Remove File' button from the UI to avoid misunderstandings.